### PR TITLE
New bool for low pT leptons

### DIFF
--- a/include/Particle.hh
+++ b/include/Particle.hh
@@ -70,6 +70,9 @@ public:
   LepID LepQual() const;
   void SetLepQual(LepID qual);
 
+  bool IsLowPt() const;
+  void SetIsLowPt(bool is_low_pt);
+
   Particle Merge(const Particle&) const;
   
   operator ParticleList() const;
@@ -88,6 +91,7 @@ private:
 
   // lepton stuff
   LepID m_LepQual;
+  bool m_IsLowPt;
   
   double m_RelIso;
   double m_MiniIso;

--- a/include/ReducedNtuple.hh
+++ b/include/ReducedNtuple.hh
@@ -148,6 +148,7 @@ private:
   vector<int>    m_ID_lep;
   vector<int>    m_SourceID_lep;
   vector<int>    m_LepQual_lep;
+  vector<int>    m_IsLowPt_lep;
   vector<int>    m_Index_lep;
 
   int m_Njet;

--- a/src/AnalysisBase.cc
+++ b/src/AnalysisBase.cc
@@ -2137,6 +2137,7 @@ ParticleList AnalysisBase<NANORun3>::GetElectrons(){
     lep.SetDzErr(Electron_dzErr[i]);
     lep.SetIP3D(Electron_ip3d[i]);
     lep.SetSIP3D(Electron_sip3d[i]);
+    lep.SetIsLowPt(false);
 
     lep.SetRelIso(Electron_pfRelIso03_all[i]);
     lep.SetMiniIso(Electron_miniPFRelIso_all[i]);
@@ -2539,20 +2540,27 @@ ParticleList AnalysisBase<NANORun3>::GetElectrons(){
       continue;
     if(LowPtElectron_ID[i] < 1.4) // need to tune after feedback from Brady
       continue;
+    
     //if(LowPtElectron_dxyErr[i] < 1.e-8 || LowPtElectron_dzErr[i] < 1.e-8)
-    //continue;
-    float dxy = LowPtElectron_dxy[i];
-    float dz = LowPtElectron_dz[i];
-    float dxy_err = LowPtElectron_dxyErr[i];
-    float dz_err = LowPtElectron_dzErr[i];
-    float IP_3D = sqrt(dxy*dxy + dz*dz);
-    float SIP_3D = IP_3D*IP_3D / sqrt((dxy*dxy)*(dxy_err*dxy_err) + (dz*dz)*(dz_err*dz_err));
+    //  continue;
+    
+    // Calculate IP_3D and SIP_3D = IP_3D / IP_3D_err for the LowPtElectron collection.
+    // - IP_3D:     3D impact parameter wrt first PV, in cm
+    // - SIP_3D:    3D impact parameter significance wrt first PV, in cm
+    float dxy       = LowPtElectron_dxy[i];
+    float dz        = LowPtElectron_dz[i];
+    float dxy_err   = LowPtElectron_dxyErr[i];
+    float dz_err    = LowPtElectron_dzErr[i];
+    float IP_3D     = sqrt(dxy*dxy + dz*dz);
+    float SIP_3D    = IP_3D*IP_3D / sqrt((dxy*dxy)*(dxy_err*dxy_err) + (dz*dz)*(dz_err*dz_err));
 
-    //if (IP_3D_sig >= 8)
-    //continue;
+    // TODO: Review and tune SIP_3D cut.
+    //if (SIP_3D >= 8)
+    //  continue;
 
-      //if(Electron_pfRelIso03_all[i]*Electron_pt[i] >= 20. + 300./Electron_pt[i])
-      //continue;
+    // FIXME: fix PFIso requirement for the LowPtElectron collection.
+    //if(Electron_pfRelIso03_all[i]*Electron_pt[i] >= 20. + 300./Electron_pt[i])
+    //  continue;
 
     Particle lep;
     lep.SetPtEtaPhiM(LowPtElectron_pt[i], LowPtElectron_eta[i],
@@ -2566,10 +2574,12 @@ ParticleList AnalysisBase<NANORun3>::GetElectrons(){
     lep.SetDzErr(LowPtElectron_dzErr[i]);
     lep.SetIP3D(IP_3D);
     lep.SetSIP3D(SIP_3D);
+    lep.SetIsLowPt(true);
 
     lep.SetRelIso(LowPtElectron_miniPFRelIso_all[i]);
     lep.SetMiniIso(LowPtElectron_miniPFRelIso_all[i]);
     lep.SetParticleID(kMedium);
+    
     //if (LowPtElectron_pt[i] < 3.0 || (LowPtElectron_pt[i] >= 3.0 && LowPtElectron_embeddedID[i] >=6))
     //  lep.SetParticleID(kTight);
     if (LowPtElectron_pt[i] < 3.0 || (LowPtElectron_pt[i] >= 3.0 && LowPtElectron_ID[i] >=1.4)) // need to tune after feedback from Brady
@@ -2615,6 +2625,7 @@ ParticleList AnalysisBase<NANORun3>::GetMuons(){
     lep.SetDzErr(Muon_dzErr[i]);
     lep.SetIP3D(Muon_ip3d[i]);
     lep.SetSIP3D(Muon_sip3d[i]);
+    lep.SetIsLowPt(false);
 
     lep.SetRelIso(Muon_pfRelIso03_all[i]);
     lep.SetMiniIso(Muon_miniPFRelIso_all[i]);

--- a/src/Particle.cc
+++ b/src/Particle.cc
@@ -24,6 +24,7 @@ Particle::Particle() : TLorentzVector() {
   m_Btag = 0.;
   m_BtagID = kNothing;
   m_LepQual = kGold;
+  m_IsLowPt = false;
 }
     
 Particle::~Particle() {}
@@ -82,6 +83,14 @@ LepID Particle::LepQual() const {
 
 void Particle::SetLepQual(LepID qual){
   m_LepQual = qual;
+}
+
+bool Particle::IsLowPt() const {
+  return m_IsLowPt;
+}
+
+void Particle::SetIsLowPt(bool is_low_pt) {
+  m_IsLowPt = is_low_pt;
 }
 
 double Particle::RelIso() const {

--- a/src/ReducedNtuple.cc
+++ b/src/ReducedNtuple.cc
@@ -415,6 +415,7 @@ TTree* ReducedNtuple<Base>::InitOutputTree(const string& sample, bool do_slim){
   tree->Branch("ID_lep", &m_ID_lep);
   tree->Branch("SourceID_lep", &m_SourceID_lep);
   tree->Branch("LepQual_lep", &m_LepQual_lep);
+  tree->Branch("IsLowPt_lep", &m_IsLowPt_lep);
   tree->Branch("Index_lep", &m_Index_lep);
 
   tree->Branch("RelIso_lep",  &m_RelIso_lep);
@@ -1497,6 +1498,7 @@ void ReducedNtuple<Base>::FillOutputTree(TTree* tree, const Systematic& sys, boo
   m_ID_lep.clear();
   m_SourceID_lep.clear();
   m_LepQual_lep.clear();
+  m_IsLowPt_lep.clear();
   m_Index_lep.clear();
   vector<int> genmatch;
   for(int i = 0; i < m_genNlep; i++)
@@ -1518,6 +1520,7 @@ void ReducedNtuple<Base>::FillOutputTree(TTree* tree, const Systematic& sys, boo
     m_SIP3D_lep.push_back(Leptons[r].SIP3D());
     m_ID_lep.push_back(Leptons[r].ParticleID());
     m_LepQual_lep.push_back(Leptons[r].LepQual());
+    m_IsLowPt_lep.push_back(Leptons[r].IsLowPt());
     int index = -1;
     double minDR = 0.1;
     for(int g = 0; g < m_genNlep; g++)


### PR DESCRIPTION
Created new bool for low pT leptons.
- Added flag for particles: m_IsLowPt
- Implemented in the Particle class, to ReducedNtuple, and to AnalysisBase.
- Set to false for standard muons and electrons and true for low pT electrons.

Addresses this issue: https://github.com/ku-cms/SUSYCascades/issues/2